### PR TITLE
Fix instruction error in Example 2 of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ To run the example, call
 python3 examples/segment_from_owl.py \
     --prompt="A tree" \
     --image_encoder="data/resnet18_image_encoder.engine" \
-    --mask_decoder="data/mobile_sam_mask_decoder.engine
+    --mask_decoder="data/mobile_sam_mask_decoder.engine" \
+    image="assets/john_1.jpg"
 ```
 
 <details>


### PR DESCRIPTION
**Issue Description:**
There is an instruction error in Example 2 of the README, preventing the proper execution of the OWL-ViT object detection section.

**Solution:**
- Corrected the instruction error.
- Updated relevant documentation to ensure users can now successfully run Example 2.